### PR TITLE
Hayes: Allow using HTTPS URL as server address (SHOOPIO-215)

### DIFF
--- a/hayes/conn.py
+++ b/hayes/conn.py
@@ -19,7 +19,7 @@ class CompletionSuggestionResults(object):
 class Hayes(object):
     def __init__(self, server, default_coll_name=None):
         self.log = logging.getLogger("Hayes")
-        if not server.startswith("http://"):
+        if "://" not in server:
             server = "http://%s/" % server
         self.session = ESSession(base_url=server)
         self.default_coll_name = default_coll_name


### PR DESCRIPTION
The `Hayes.__init__` used to prepend "http://" to every server address
that does not start with "http://", which does not work for HTTPS urls.
Make it prepend the "http://" if there is no "://" in the given address.

In the odd case that address with "://" in middle is desired, the scheme
must be specified now.  This should not be a problem.

This fix is required to make Hayes work for shoop.io, since there the
ElasticSearch is accessed through HTTPS.

Refs SHOOPIO-215