### PR TITLE
Fix django_interop.get_connection (SHOOPIO-215)

### DIFF
--- a/hayes/django_interop/base.py
+++ b/hayes/django_interop/base.py
@@ -36,5 +36,5 @@ def get_index_by_name(name):
 def get_connection(**kwargs):
     kwargs.setdefault("connection_class", Hayes)
     kwargs.setdefault("server", settings.HAYES_SERVER)
-    kwargs.setdefault("index", settings.HAYES_DEFAULT_INDEX)
+    kwargs.setdefault("default_coll_name", settings.HAYES_DEFAULT_INDEX)
     return (kwargs.pop("connection_class"))(**kwargs)


### PR DESCRIPTION
Hayes class does not have `index` parameter anymore.  It was renamed to
`default_coll_name` in commit b3402f876.  Amend `get_connection` for
that change.

This is needed to allow using ElasticSearch through Hayes in shoop.io.

Refs SHOOPIO-215